### PR TITLE
Add explicit dot for Perl v5.26+

### DIFF
--- a/docx2txt.pl
+++ b/docx2txt.pl
@@ -285,7 +285,7 @@ die $usage if (@ARGV > 2 || $ARGV[0] eq '-h');
 my %config;
 
 if (-f "docx2txt.config") {
-    %config = do 'docx2txt.config';
+    %config = do './docx2txt.config';
 } elsif (-f "$userConfigDir/docx2txt.config") {
     %config = do "$userConfigDir/docx2txt.config";
 } elsif (-f "$systemConfigDir/docx2txt.config") {


### PR DESCRIPTION
See: https://wiki.gentoo.org/wiki/Project:Perl/5.26_Known_Issues#No_current_directory_in_library_loading_path_anymore